### PR TITLE
bug: canvas is accessing incorrect memory

### DIFF
--- a/main.c
+++ b/main.c
@@ -63,6 +63,9 @@ void canvas_draw(Canvas *c, Grid g) {
 
             for (int h = 0; h < b.h; ++h){
                 for (int w = 0; w < b.w; ++w) {
+                    // TODO: (Critical) this is accessing grid memory when
+                    // dealing with large resolutions making the program to
+                    // segfault.
                     c->pixels[box_idx + (w + h * WINDOW_WIDTH)] = p;
                 }
             }


### PR DESCRIPTION
When painting the canvas is accessing memory beloging to grid, making
the program to segfault.

Check issue #15 

this pull request only marks the problems, need a fix ASAP